### PR TITLE
Use SecurityInfo throughout instead of User.Id directly (currently inconsistent)

### DIFF
--- a/Rhino.Security/Services/AuthorizationService.cs
+++ b/Rhino.Security/Services/AuthorizationService.cs
@@ -166,7 +166,7 @@ namespace Rhino.Security.Services
 				.CreateAlias("entityGroup.Entities", "entityKey", JoinType.LeftOuterJoin)
 				.SetProjection(Projections.Property("Allow"))
 				.Add(Restrictions.In("op.Name", operationNames))
-				.Add(Restrictions.Eq("User", user) 
+				.Add(Restrictions.Eq("User.Id", user.SecurityInfo.Identifier)
 				|| Subqueries.PropertyIn("UsersGroup.Id", 
 										 SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
 				.Add(

--- a/Rhino.Security/Services/PermissionsService.cs
+++ b/Rhino.Security/Services/PermissionsService.cs
@@ -40,7 +40,7 @@ namespace Rhino.Security.Services
 		public Permission[] GetPermissionsFor(IUser user)
 		{
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Expression.Eq("User", user)
+				.Add(Expression.Eq("User.Id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())));
 
@@ -58,7 +58,7 @@ namespace Rhino.Security.Services
 		{
 			string[] operationNames = Strings.GetHierarchicalOperationNames(operationName);
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Expression.Eq("User", user)
+				.Add(Expression.Eq("User.Id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
                 .Add(Expression.IsNull("EntitiesGroup"))
@@ -97,7 +97,7 @@ namespace Rhino.Security.Services
 			EntitiesGroup[] entitiesGroups = authorizationRepository.GetAssociatedEntitiesGroupsFor(entity);
 
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Expression.Eq("User", user)
+				.Add(Expression.Eq("User.Id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
 				.Add(Expression.Eq("EntitySecurityKey", key) || Expression.In("EntitiesGroup", entitiesGroups));
@@ -125,7 +125,7 @@ namespace Rhino.Security.Services
 				(Restrictions.Eq("EntitySecurityKey", key) || Restrictions.In("EntitiesGroup", entitiesGroups)) ||
 				(Restrictions.IsNull("EntitiesGroup") && Restrictions.IsNull("EntitySecurityKey"));
 			DetachedCriteria criteria = DetachedCriteria.For<Permission>()
-				.Add(Restrictions.Eq("User", user)
+				.Add(Restrictions.Eq("User.Id", user.SecurityInfo.Identifier)
 				     || Subqueries.PropertyIn("UsersGroup.Id",
 				                              SecurityCriterions.AllGroups(user).SetProjection(Projections.Id())))
 				.Add(onCriteria)


### PR DESCRIPTION
Implemented OnBehalfOf functionality along the lines of your blog post (http://ayende.com/blog/4618/security-models-on-behalf-of) successfully but had to make a couple of changes to rhino security.

SecurityInfo isn't constantly used to get the user id (was in SecurityCriterions for example but not in these two files) so have implemented this minor change.

Allows a user to act on behalf of another by simple returning another user's SecurityInfo, auditing etc can be handled against the user that is currently logged in.
